### PR TITLE
Add setBackgroundFromUrl method

### DIFF
--- a/src/SketchField.jsx
+++ b/src/SketchField.jsx
@@ -546,6 +546,36 @@ class SketchField extends PureComponent {
     img.src = dataUrl
   };
 
+  /**
+   * Sets the background from the url given
+   *
+   * @param url the url of the image to be used as a background
+   * @param options
+   */
+  setBackgroundFromUrl = (url, options = {}) => {
+    let canvas = this._fc;
+    if (options.stretched) {
+      delete options.stretched;
+      Object.assign(options, {
+        width: canvas.width,
+        height: canvas.height
+      })
+    }
+    if (options.stretchedX) {
+      delete options.stretchedX;
+      Object.assign(options, {
+        width: canvas.width
+      })
+    }
+    if (options.stretchedY) {
+      delete options.stretchedY;
+      Object.assign(options, {
+        height: canvas.height
+      })
+    }
+    canvas.setBackgroundImage(url, () => canvas.renderAll(), options);
+  };
+
   addText = (text, options = {}) => {
     let canvas = this._fc;
     let iText = new fabric.IText(text, options);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,13 @@
 declare module 'react-sketch' {
 	import * as React from 'react'
 
+	export interface BackgroundImageOptions {
+		stretched?: boolean
+		stretchedX?: boolean
+		stretchedY?: boolean
+		[name: string]: any
+	}
+
 	export class SketchField extends React.PureComponent<{
 		// the color of the line
 		lineColor?: string
@@ -169,12 +176,15 @@ declare module 'react-sketch' {
 		 * @param dataUrl the dataUrl to be used as a background
 		 * @param options
 		 */
-		setBackgroundFromDataUrl(dataUrl: string, options?: {
-			stretched?: boolean
-			stretchedX?: boolean
-			stretchedY?: boolean
-			[name: string]: any
-		}): void
+		setBackgroundFromDataUrl(dataUrl: string, options?: BackgroundImageOptions): void
+
+		/**
+		 * Sets the background from the url given
+		 *
+		 * @param url the url of the image to be used as a background
+		 * @param options
+		 */
+		setBackgroundFromUrl(url: string, options?: BackgroundImageOptions): void
 		
 		addText(text: string, options?: {}): void
 		


### PR DESCRIPTION
This allows loading of cross origin images by adding `crossOrigin: 'anonymous'` to the options object. Using the existing `setBackgroundFromDataUrl` method it is not possible to use cross origin images as that implementation loads the `Image` first, and doesn't include a `crossOrigin` setting.

The same cross origin issue probably exists in `addImg` but I have not had a chance to investigate yet!